### PR TITLE
Setup SimpleStorage contract using Brownie

### DIFF
--- a/brownie-simple-storage/.gitattributes
+++ b/brownie-simple-storage/.gitattributes
@@ -1,0 +1,2 @@
+*.sol linguist-language=Solidity
+*.vy linguist-language=Python

--- a/brownie-simple-storage/.gitignore
+++ b/brownie-simple-storage/.gitignore
@@ -1,0 +1,6 @@
+__pycache__
+.env
+.history
+.hypothesis/
+build/
+reports/

--- a/brownie-simple-storage/brownie-config.yaml
+++ b/brownie-simple-storage/brownie-config.yaml
@@ -1,0 +1,3 @@
+dotenv: .env
+wallets:
+  from_key: ${MM_PRIVATE_KEY}

--- a/brownie-simple-storage/contracts/SimpleStorage.sol
+++ b/brownie-simple-storage/contracts/SimpleStorage.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.6.0;
+
+contract SimpleStorage {
+    uint256 favoriteNumber;
+    bool favoriteBool;
+
+    struct People {
+        uint256 favoriteNumber;
+        string name;
+    }
+
+    People[] public people;
+    mapping(string => uint256) public nameToFavoriteNumber;
+
+    function store(uint256 _favoriteNumber) public returns (uint256) {
+        favoriteNumber = _favoriteNumber;
+        return favoriteNumber;
+    }
+
+    function retrieve() public view returns (uint256) {
+        return favoriteNumber;
+    }
+
+    function addPerson(string memory _name, uint256 _favoriteNumber) public {
+        people.push(People(_favoriteNumber, _name));
+        nameToFavoriteNumber[_name] = _favoriteNumber;
+    }
+}

--- a/brownie-simple-storage/scripts/deploy.py
+++ b/brownie-simple-storage/scripts/deploy.py
@@ -1,0 +1,28 @@
+from brownie import accounts, config, SimpleStorage, network
+import os
+
+
+def deploy_simple_storage():
+    # account = accounts.load("MetaMask_TEST_WALLET")
+    # account = accounts.add(os.getenv("MM_PRIVATE_KEY"))
+    # account = accounts.add(config["wallets"]["from_key"])
+    # print(account)
+    account = get_account()
+    simple_storage = SimpleStorage.deploy({"from": account})
+    stored_value = simple_storage.retrieve()
+    print(stored_value)
+    transaction = simple_storage.store(15, {"from": account})
+    transaction.wait(1)
+    updated_stored_value = simple_storage.retrieve()
+    print(updated_stored_value)
+
+
+def get_account():
+    if network.show_active() == "development":
+        return accounts[0]
+    else:
+        return accounts.add(config["wallets"]["from_key"])
+
+
+def main():
+    deploy_simple_storage()

--- a/brownie-simple-storage/scripts/read_value.py
+++ b/brownie-simple-storage/scripts/read_value.py
@@ -1,0 +1,10 @@
+from brownie import SimpleStorage, accounts, config
+
+
+def read_contract():
+    simple_storage = SimpleStorage[-1]
+    print(simple_storage.retrieve())
+
+
+def main():
+    read_contract()

--- a/brownie-simple-storage/tests/test_simple_storage.py
+++ b/brownie-simple-storage/tests/test_simple_storage.py
@@ -1,0 +1,23 @@
+from brownie import SimpleStorage, accounts
+
+
+def test_deploy():
+    # Arrange
+    account = accounts[0]
+    # Act
+    simple_storage = SimpleStorage.deploy({"from": account})
+    starting_value = simple_storage.retrieve()
+    expected_value = 0
+    # Assert
+    assert starting_value == expected_value
+
+
+def test_updating_storage():
+    # Arrange
+    account = accounts[0]
+    # Act
+    simple_storage = SimpleStorage.deploy({"from": account})
+    simple_storage.store(15, {"from": account})
+    expected_value = 15
+    # Assert
+    assert simple_storage.retrieve() == expected_value


### PR DESCRIPTION
- Write two scripts: `deploy.py` and a `read_value.py`
- Write two unit tests
- Test out three different methods to work with wallet addresses
  1. save MetaMask wallet directly into brownie using `brownie accounts new <id>`
  2. add MM wallet an OS environment variable
  3. add MM wallet as an OS environment variable and then pull it in using `brownie-config.yaml`
